### PR TITLE
added links of resume drive

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -134,7 +134,7 @@ const Contact = () => {
               type='button'
               href=""
               className='bg-tertiary py-3 px-8 rounded-xl outline-none w-fit text-white font-bold shadow-md shadow-primary my-2'
-              onClick={() => window.open('https://drive.google.com/file/d/1eRHHGPkPHN84o3zy6a0jOPdZVDw-bIoE/view', '_blank')}
+              onClick={() => window.open('https://drive.google.com/file/d/1-UXAiTXuHvVj5WIj4mL4JpK0uUJh_7i-/view?usp=drive_link', '_blank')}
             >Résumé
             </a>
           </div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -19,7 +19,7 @@ const Hero = () => {
           </h1>
           <p className={`${styles.heroSubText} mt-2 text-white-100`}>
             Innovative, award-winning Software Developer & GenAI Consultant.<br className="sm:block hidden" />
-            Specialist in Python, JavaFReact, LLMs, and scalable cloud-based AI solutions.<br className="sm:block hidden" />
+            Specialist in Python, Java, LLMs, and scalable cloud-based AI solutions.<br className="sm:block hidden" />
             Architected AI platforms and IDE plugins adopted by industry leaders, recognized for technology-driven impact.<br className="sm:block hidden" />
             <span className="italic text-secondary">“Great vision without great people is irrelevant.” – Jim Collins</span>
           </p>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -85,29 +85,15 @@ const services = [
 ];
 
 const technologies = [
-  {
-    name: "Python",
-    icon: python
-  },
+  {name: "Python", icon: python},
   {name: "LangChain", icon: langchain},
-  {
-    name: "LangFlow", icon: langflow
-  },
   {name: "Java", icon: java},
-  {
-    name: "Django",
-    icon: django
-  },
-  {
-    name: "Postgres",
-    icon: postgres
-  },
   {name: "AWS", icon: aws},
   {name: "Azure", icon: azure},
   // {name: "Jenkins", icon: jenkins},
   // {name: "Kubernetes", icon: kubernetes},
   // {name: "Linux", icon: linux},
-  // {name: "Docker", icon: docker},
+  {name: "Docker", icon: docker},
   // {name: "Kafka", icon: kafka},
   // {name: "Streamlit", icon: streamlit},
 ];


### PR DESCRIPTION
## Summary by Sourcery

Update the resume link, streamline the displayed technologies, and fix a typo in the hero section to reflect the current tech stack.

Enhancements:
- Update the resume button to open the new Google Drive link
- Simplify and clean up the technologies array by inlining entries, removing unused items (LangFlow, Django, Postgres), and re-enabling Docker
- Correct the hero section subtitle by replacing the incorrect 'JavaFReact' with 'Java'